### PR TITLE
Do not imply packages for compatibility

### DIFF
--- a/package.js
+++ b/package.js
@@ -31,7 +31,6 @@ Package.onUse(function (api) {
     ];
 
     api.use(packages);
-    api.imply(packages);
 
     api.mainModule('main.client.js', 'client');
     api.mainModule('main.server.js', 'server');


### PR DESCRIPTION
Using imply in package.js for all packages causes some problems for user with other preferences.

E.g one might not need and want simple-schema but use [Astronomy](https://github.com/jagi/meteor-astronomy) instead. 
Also this causes conflicts with packages replacing `ecmascript` like [meteor-webpack](https://github.com/thereactivestack/meteor-webpack)
Simply removing the imply from the `package.js` did work for me. Seems like everything is still working fine.