### PR TITLE
Fix issue with $regex operator

### DIFF
--- a/lib/query/lib/deepClone.js
+++ b/lib/query/lib/deepClone.js
@@ -20,6 +20,8 @@ export default function deepClone(object) {
             clone[key] = deepCloneArray(value);
         } else if (_.isFunction(value)) {
             clone[key] = value;
+        } else if (_.isRegExp(value)) {
+            clone[key] = value;
         } else if (_.isObject(value)) {
             clone[key] = deepClone(value);
         } else {


### PR DESCRIPTION
Currently `col.createQuery({ $filters: { name: { $regex: ...  } } }).fetch()` doesn't work