### PR TITLE
Fixed deepClone of Date objects

### DIFF
--- a/lib/query/lib/deepClone.js
+++ b/lib/query/lib/deepClone.js
@@ -22,6 +22,8 @@ export default function deepClone(object) {
             clone[key] = value;
         } else if (_.isRegExp(value)) {
             clone[key] = value;
+        } else if (_.isDate(value)) {
+            clone[key] = value;
         } else if (_.isObject(value)) {
             clone[key] = deepClone(value);
         } else {


### PR DESCRIPTION
I found a bug in grapher which caused Date queries to fail.

The deepClone in grapher does transform a $filter like this:
```js
{
  $filters: {
    dateField: { $gte: new Date() }
  }
}
```
to an empty object:
```js
{
  $filters: {
    dateField: {}
  }
}
```

My solution is to add a `_.isDate` check to the existing checks in the deepClone function. This works for JS Dates but there might be some more problematic types.

Maybe a better solution would be to replace the custom deepClone with the lodash deepClone?