### PR TITLE
Adds promise (sync) variants of getCount

### DIFF
--- a/lib/namedQuery/namedQuery.client.js
+++ b/lib/namedQuery/namedQuery.client.js
@@ -75,6 +75,14 @@ export default class extends Base {
     }
 
     /**
+     * Gets the count of matching elements in sync.
+     * @returns {any}
+     */
+    async getCountSync() {
+        return await callWithPromise(this.name + '.count', prepareForProcess(this.body, this.params));
+    }
+
+    /**
      * Gets the count of matching elements.
      * @param callback
      * @returns {any}

--- a/lib/query/query.client.js
+++ b/lib/query/query.client.js
@@ -75,6 +75,14 @@ export default class Query extends Base {
     }
 
     /**
+     * Gets the count of matching elements in sync.
+     * @returns {any}
+     */
+    async getCountSync() {
+        return await callWithPromise(this.name + '.count', prepareForProcess(this.body, this.params));
+    }
+
+    /**
      * Gets the count of matching elements.
      * @param callback
      * @returns {any}

--- a/lib/query/testing/client.test.js
+++ b/lib/query/testing/client.test.js
@@ -210,5 +210,9 @@ describe('Query Client Tests', function () {
         assert.isObject(result);
         assert.isString(result._id);
         assert.isArray(result.posts);
+
+        result = await query.getCountSync();
+
+        assert.isNumber(result);
     })
 });


### PR DESCRIPTION
This PR adds new promise support also for getCount methods for both query and namedQuery on the client.

I was wondering why promise support has not been implemented using the same methods used for traditional callback approach. Is it to have these Exceptions complaining about a missing callback function?

e.g `getCount(callback)` could be easily implemented as

```js
async getCount(callback) {
  return await callWithPromise(this.name + '.count', prepareForProcess(this.body, this.params), callback);
}
```

It would still be absolutely fine to call it by using the callback and ignoring the returned promise.