### PR TITLE
Add a method to get all attached links

### DIFF
--- a/lib/links/extension.js
+++ b/lib/links/extension.js
@@ -26,7 +26,7 @@ _.extend(Mongo.Collection.prototype, {
     
     getLinks() {
         return this[linkStorage];
-    }
+    },
 
     getLinker(name) {
         if (this[linkStorage]) {

--- a/lib/links/extension.js
+++ b/lib/links/extension.js
@@ -23,6 +23,10 @@ _.extend(Mongo.Collection.prototype, {
             });
         });
     },
+    
+    getLinks() {
+        return this[linkStorage];
+    }
 
     getLinker(name) {
         if (this[linkStorage]) {


### PR DESCRIPTION
I'd like to have a method that returns all the links attached to a collection.

See issue #96 