### PR TITLE
fix issue with adding fields from $filters

### DIFF
--- a/lib/query/nodes/collectionNode.js
+++ b/lib/query/nodes/collectionNode.js
@@ -91,7 +91,7 @@ export default class CollectionNode {
             // special handling for the $meta filter and conditional operators
             if (!_.contains(['$or', '$nor', '$not', '$and', '$meta'], field)) {
                 // if the field or the parent of the field already exists, don't add it
-                if(!_.has(options.fields,field.split('.')[0])){
+                if (!_.has(options.fields, field.split('.')[0])){
                     hasAddedAnyField = true;
                     options.fields[field] = 1;
                 }

--- a/lib/query/nodes/collectionNode.js
+++ b/lib/query/nodes/collectionNode.js
@@ -90,8 +90,11 @@ export default class CollectionNode {
         _.each(filters, (value, field) => {
             // special handling for the $meta filter and conditional operators
             if (!_.contains(['$or', '$nor', '$not', '$and', '$meta'], field)) {
-                hasAddedAnyField = true;
-                options.fields[field] = 1;
+                // if the field or the parent of the field already exists, don't add it
+                if(!_.contains(_.keys(options.fields),field.split('.')[0])){
+                    hasAddedAnyField = true;
+                    options.fields[field] = 1;
+                }
             }
         });
 

--- a/lib/query/nodes/collectionNode.js
+++ b/lib/query/nodes/collectionNode.js
@@ -91,7 +91,7 @@ export default class CollectionNode {
             // special handling for the $meta filter and conditional operators
             if (!_.contains(['$or', '$nor', '$not', '$and', '$meta'], field)) {
                 // if the field or the parent of the field already exists, don't add it
-                if(!_.contains(_.keys(options.fields),field.split('.')[0])){
+                if(!_.has(options.fields,field.split('.')[0])){
                     hasAddedAnyField = true;
                     options.fields[field] = 1;
                 }


### PR DESCRIPTION
```
Meteor.users.createQuery({
  $filters:{'profile.online':true},
  username:1,
  profile:1
}
```
If you try to create a query like this, both 'profile.online' and 'profile' get added to options.fields, causing the error 
> "MinimongoError: both profile.online and profile found in fields option, using both of them may trigger unexpected behavior."

This adds a check to not add fields if options.fields already contains their parent.