### PR TITLE
Named query validation/firewall changes

### DIFF
--- a/lib/namedQuery/expose/extension.js
+++ b/lib/namedQuery/expose/extension.js
@@ -68,6 +68,10 @@ _.extend(NamedQuery.prototype, {
                 this.unblock();
                 self._validateParams(newParams);
 
+                if (self.exposeConfig.firewall) {
+                    self.exposeConfig.firewall.call(this, this.userId, newParams);
+                }
+
                 return self.clone(newParams).getCount();
             }
         })
@@ -94,7 +98,16 @@ _.extend(NamedQuery.prototype, {
 
     _validateParams(params) {
         if (params && this.exposeConfig.schema) {
-            (new SimpleSchema(this.exposeConfig.schema)).validate(params);
+            if (process.env.NODE_ENV !== 'production') {
+                try {
+                    (new SimpleSchema(this.exposeConfig.schema)).validate(params);
+                } catch (validationError) {
+                    console.error(`Invalid parameters supplied to query ${this.queryName}`, validationError);
+                    throw validationError; // rethrow
+                }
+            } else {
+                (new SimpleSchema(this.exposeConfig.schema)).validate(params);
+            }
         }
     }
 });


### PR DESCRIPTION
Currently any param validation errors raised in `_validateParams` are not logged anywhere, which can make debugging difficult. This PR causes any errors to be output via `console.error` when not running in production mode.

Additionally, the count method of each named query will run the firewall method before returning any data.