### PR TITLE
Text search

### DIFF
--- a/lib/query/lib/prepareForProcess.js
+++ b/lib/query/lib/prepareForProcess.js
@@ -44,12 +44,40 @@ function applyPagination(body, _params) {
     }
 }
 
-export default (_body, _params = {}) => {
+function handleTextFilters(data, isClient) {
+    _.each(data, field => {
+        if (field.$text) {
+            if (isClient) {
+                let $or = _.map(field.$text.$fields, (val, key) => {
+                    return {
+                        [key]: {
+                            $regex:field.$text.$search,
+                            $options: field.$text.$caseSensitive ? '' : 'i'
+                        }
+                    }
+                })
+                delete field.$text
+                if (_.isEmpty(field)) {
+                    field = {$or}
+                } else {
+                    field = {$and:[field, {$or}]}
+                }
+            } else {
+                delete field.$text.$fields
+            }
+        } else if (_.isObject(field)) {
+            handleTextFilters(field, isClient)
+        }
+    })
+}
+
+export default (_body, _params = {}, isClient) => {
     let body = deepClone(_body);
     let params = deepClone(_params);
 
     applyPagination(body, params);
     applyFilterRecursive(body, params);
-
+    handleTextFilters(body, isClient)
+    
     return body;
 }

--- a/lib/query/query.client.js
+++ b/lib/query/query.client.js
@@ -127,7 +127,7 @@ export default class Query extends Base {
      * @private
      */
     _fetchReactive(options = {}) {
-        let body = prepareForProcess(this.body, this.params);
+        let body = prepareForProcess(this.body, this.params, true);
         if (!options.allowSkip && body.$options && body.$options.skip) {
             delete body.$options.skip;
         }

--- a/lib/query/testing/bootstrap/fixtures.js
+++ b/lib/query/testing/bootstrap/fixtures.js
@@ -8,67 +8,65 @@ import Posts from './posts/collection';
 import Tags from './tags/collection';
 import Groups from './groups/collection';
 
-Meteor.startup(() => {
-    Authors.remove({});
-    Comments.remove({});
-    Posts.remove({});
-    Tags.remove({});
-    Groups.remove({});
+Authors.remove({});
+Comments.remove({});
+Posts.remove({});
+Tags.remove({});
+Groups.remove({});
 
-    const AUTHORS = 6;
-    const POST_PER_USER = 6;
-    const COMMENTS_PER_POST = 6;
-    const TAGS = ['JavaScript', 'Meteor', 'React', 'Other'];
-    const GROUPS = ['JavaScript', 'Meteor', 'React', 'Other'];
-    const COMMENT_TEXT_SAMPLES = [
-        'Good', 'Bad', 'Neutral'
-    ];
+const AUTHORS = 6;
+const POST_PER_USER = 6;
+const COMMENTS_PER_POST = 6;
+const TAGS = ['JavaScript', 'Meteor', 'React', 'Other'];
+const GROUPS = ['JavaScript', 'Meteor', 'React', 'Other'];
+const COMMENT_TEXT_SAMPLES = [
+    'Good', 'Bad', 'Neutral'
+];
 
-    console.log('[testing] Loading test fixtures ...');
+console.log('[testing] Loading test fixtures ...');
 
-    let tags = TAGS.map(name => Tags.insert({name}));
-    let groups = GROUPS.map(name => Groups.insert({name}));
-    let authors = _.range(AUTHORS).map(idx => {
-        return Authors.insert({
-            name: 'Author - ' + idx,
-            profile: {
-                firstName: 'First Name - ' + idx,
-                lastName: 'Last Name - ' + idx
-            }
-        });
+let tags = TAGS.map(name => Tags.insert({name}));
+let groups = GROUPS.map(name => Groups.insert({name}));
+let authors = _.range(AUTHORS).map(idx => {
+    return Authors.insert({
+        name: 'Author - ' + idx,
+        profile: {
+            firstName: 'First Name - ' + idx,
+            lastName: 'Last Name - ' + idx
+        }
+    });
+});
+
+_.each(authors, (author) => {
+    const authorPostLink = Authors.getLink(author, 'posts');
+    const authorGroupLink = Authors.getLink(author, 'groups');
+
+    authorGroupLink.add(_.sample(groups), {
+        isAdmin: _.sample([true, false])
     });
 
-    _.each(authors, (author) => {
-        const authorPostLink = Authors.getLink(author, 'posts');
-        const authorGroupLink = Authors.getLink(author, 'groups');
+    _.each(_.range(POST_PER_USER), (idx) => {
+        let post = {
+            title: `User Post - ${idx}`
+        };
 
-        authorGroupLink.add(_.sample(groups), {
-            isAdmin: _.sample([true, false])
-        });
+        authorPostLink.add(post);
+        const postCommentsLink = Posts.getLink(post, 'comments');
+        const postTagsLink = Posts.getLink(post, 'tags');
+        const postGroupLink = Posts.getLink(post, 'group');
+        postGroupLink.set(_.sample(groups), {random: Random.id()});
 
-        _.each(_.range(POST_PER_USER), (idx) => {
-            let post = {
-                title: `User Post - ${idx}`
+        postTagsLink.add(_.sample(tags));
+
+        _.each(_.range(COMMENTS_PER_POST), (idx) => {
+            let comment = {
+                text: _.sample(COMMENT_TEXT_SAMPLES)
             };
 
-            authorPostLink.add(post);
-            const postCommentsLink = Posts.getLink(post, 'comments');
-            const postTagsLink = Posts.getLink(post, 'tags');
-            const postGroupLink = Posts.getLink(post, 'group');
-            postGroupLink.set(_.sample(groups), {random: Random.id()});
-
-            postTagsLink.add(_.sample(tags));
-
-            _.each(_.range(COMMENTS_PER_POST), (idx) => {
-                let comment = {
-                    text: _.sample(COMMENT_TEXT_SAMPLES)
-                };
-
-                postCommentsLink.add(comment);
-                Comments.getLink(comment, 'author').set(_.sample(authors));
-            })
+            postCommentsLink.add(comment);
+            Comments.getLink(comment, 'author').set(_.sample(authors));
         })
-    });
+    })
+});
 
-    console.log('[ok] fixtures have been loaded.');
-})
+console.log('[ok] fixtures have been loaded.');


### PR DESCRIPTION
First draft.

The way I got around not knowing what the text index looks like on the client is by adding a $fields property to $text, where you specify which fields to search on the client. These should of course be the same as the index you set up on the server.

You can now do text searches like this:
```js
$filters:{
    $text: {
        $search: 'asdasd',
        $fields: ['username', 'profile.first_name', 'profile.last_name']
    }
}
```

Maybe a more convenient solution could be something like:
Create `Mongo.Collection.prototype.textIndex()`, which you call on both the client and server. On the server it calls _ensureIndex, and on the client it saves the fields on the collection, so that they can be used by the conversion function.

What do you think?