### PR TITLE
Possible mistake in naming of reviewedBooksCache

### DIFF
--- a/docs/denormalization.md
+++ b/docs/denormalization.md
@@ -114,7 +114,7 @@ to send them an email about a new book, or a soap opera.
 ```js
 const dramaticUsers = Meteor.users.createQuery({
     $filters: {
-        'bookReviewsCache.type': 'Drama'
+        'reviewedBooksCache.type': 'Drama'
     },
     email: 1,
 }).fetch();


### PR DESCRIPTION
I could be wrong on this, but I got lost trying to follow this.  Shouldn't the filter review to `reviewedBooksCache` and not `bookReviewsCache`. My apologies if not, guess I'm not understanding it.