### PR TITLE
Sync fetching for named queries fix

### DIFF
--- a/lib/namedQuery/namedQuery.client.js
+++ b/lib/namedQuery/namedQuery.client.js
@@ -75,7 +75,7 @@ export default class extends Base {
             throw new Meteor.Error('This query is reactive, meaning you cannot use promises to fetch the data.');
         }
 
-        return await callWithPromise(this.name, prepareForProcess(this.body, this.params));
+        return await callWithPromise(this.name, this.params);
     }
 
     /**
@@ -127,7 +127,7 @@ export default class extends Base {
             throw new Meteor.Error('This query is reactive, meaning you cannot use promises to fetch the data.');
         }
 
-        return await callWithPromise(this.name + '.count', prepareForProcess(this.body, this.params));
+        return await callWithPromise(this.name + '.count', this.params);
     }
 
     /**

--- a/lib/namedQuery/testing/client.test.js
+++ b/lib/namedQuery/testing/client.test.js
@@ -40,6 +40,20 @@ describe('Named Query', function() {
         });
     });
 
+    it('Should return proper values using query directly via import - sync', async function() {
+        const query = postListExposure.clone({ title: 'User Post - 3' });
+
+        const res = await query.fetchSync();
+
+        assert.isTrue(res.length > 0);
+
+        _.each(res, post => {
+            assert.equal(post.title, 'User Post - 3');
+            assert.isObject(post.author);
+            assert.isObject(post.group);
+        });
+    });
+
     it('Should work with count', function(done) {
         const query = postListExposure.clone({ title: 'User Post - 3' });
 
@@ -47,6 +61,13 @@ describe('Named Query', function() {
             assert.equal(6, res);
             done();
         });
+    });
+
+    it('Should work with count - sync', async function() {
+        const query = postListExposure.clone({ title: 'User Post - 3' });
+
+        const count = await query.getCountSync();
+        assert.equal(6, count);
     });
 
     it('Should work with reactive counts', function(done) {

--- a/lib/query/testing/link-cache/fixtures.js
+++ b/lib/query/testing/link-cache/fixtures.js
@@ -10,7 +10,7 @@ export let groupIds = [];
 export let authorIds = [];
 export let postIds = [];
 
-Meteor.startup(() => {
+export default function createFixtures() {
     for (let i = 0; i < CATEGORIES; i++) {
         const categoryId = Categories.insert({
             name: `Category ${i}`
@@ -53,25 +53,25 @@ Meteor.startup(() => {
             }
         }
     });
+}
 
-    function createPost(authorId) {
-        const postId = Posts.insert({
-            title: `Post ${postIds.length}`,
-            createdAt: new Date(),
-        });
+function createPost(authorId) {
+    const postId = Posts.insert({
+        title: `Post ${postIds.length}`,
+        createdAt: new Date(),
+    });
 
-        postIds.push(postId);
+    postIds.push(postId);
 
-        const authorLink = Posts.getLink(postId, 'author');
-        authorLink.set(authorId);
+    const authorLink = Posts.getLink(postId, 'author');
+    authorLink.set(authorId);
 
-        const randomCategoryId = categoryIds[Math.floor(Math.random()*categoryIds.length)];
+    const randomCategoryId = categoryIds[Math.floor(Math.random()*categoryIds.length)];
 
-        const categoriesLink = Posts.getLink(postId, 'categories');
-        categoriesLink.add(randomCategoryId, {
-            createdAt: new Date(),
-        });
+    const categoriesLink = Posts.getLink(postId, 'categories');
+    categoriesLink.add(randomCategoryId, {
+        createdAt: new Date(),
+    });
 
-        return postId;
-    }
-});
+    return postId;
+}

--- a/lib/query/testing/link-cache/server.test.js
+++ b/lib/query/testing/link-cache/server.test.js
@@ -1,4 +1,4 @@
-import './fixtures';
+import createFixtures from './fixtures';
 import { createQuery } from 'meteor/cultofcoders:grapher';
 import {
     Authors,
@@ -9,9 +9,9 @@ import {
 } from './collections';
 
 describe('Query Link Denormalization', function() {
-    // fixtures run in Meteor.startup()
-    // wait for them to load first
-    Meteor._sleepForMs(10000);
+    before(() => {
+        createFixtures();
+    });
 
     it('Should not cache work with nested options', function() {
         let query = Posts.createQuery({


### PR DESCRIPTION
Fixed client side named query sync functions *fetchSync()* and *getCountSync()*. Instead of query body, **params** must passed to the Meteor.call().

Fixes #260 