### PR TITLE
Reducers and deeply nested fields inside links fixes

### DIFF
--- a/lib/query/hypernova/buildAggregatePipeline.js
+++ b/lib/query/hypernova/buildAggregatePipeline.js
@@ -1,4 +1,5 @@
 import { _ } from 'meteor/underscore';
+import {SAFE_DOTTED_FIELD_REPLACEMENT} from './constants';
 
 export default function (childCollectionNode, filters, options, userId) {
     let containsDottedFields = false;
@@ -31,7 +32,7 @@ export default function (childCollectionNode, filters, options, userId) {
         if (field.indexOf('.') >= 0) {
             containsDottedFields = true;
         }
-        const safeField = field.replace('.', '___');
+        const safeField = field.replace(/\./g, SAFE_DOTTED_FIELD_REPLACEMENT);
         dataPush[safeField] = '$' + field
     });
 

--- a/lib/query/hypernova/lib/snapBackDottedFields.js
+++ b/lib/query/hypernova/lib/snapBackDottedFields.js
@@ -6,7 +6,7 @@ export default function (aggregationResult) {
         result.data = result.data.map(document => {
             _.each(document, (value, key) => {
                 if (key.indexOf(SAFE_DOTTED_FIELD_REPLACEMENT) >= 0) {
-                    document[key.replace(SAFE_DOTTED_FIELD_REPLACEMENT, '.')] = value;
+                    document[key.replace(new RegExp(SAFE_DOTTED_FIELD_REPLACEMENT, 'g'), '.')] = value;
                     delete document[key];
                 }
             });

--- a/lib/query/lib/recursiveFetch.js
+++ b/lib/query/lib/recursiveFetch.js
@@ -31,8 +31,22 @@ function fetch(node, parentObject) {
 
     _.each(node.collectionNodes, collectionNode => {
         _.each(results, result => {
-            result[collectionNode.linkName] = fetch(collectionNode, result);
+            const collectionNodeResults = fetch(collectionNode, result);
+            result[collectionNode.linkName] = collectionNodeResults;
             //delete result[node.linker.linkStorageField];
+
+            /**
+             * Push into the results, because snapBackCaches() in prepareForDelivery does not work otherwise.
+             * This is non-optimal, can we be sure that every item in results contains _id and add only if not in
+             * the results?
+             *
+             * Other possible ways:
+             * - do something like assemble() in storeHypernovaResults
+             * - pass node.results to accessor above and find with sift
+             */
+
+            const currentIds = _.pluck(collectionNode.results, '_id');
+            collectionNode.results.push(...collectionNodeResults.filter(res => !_.contains(currentIds, res._id)));
         })
     });
 

--- a/lib/query/reducers/lib/cleanReducerLeftovers.js
+++ b/lib/query/reducers/lib/cleanReducerLeftovers.js
@@ -1,3 +1,5 @@
+import dot from 'dot-object';
+
 /**
  * @param root
  */
@@ -16,7 +18,7 @@ export default function cleanReducerLeftovers(root) {
 
     _.each(root.fieldNodes, node => {
         if (node.scheduledForDeletion) {
-            cleanNestedFields(node.name.split('.'), root.results);
+            cleanNestedFields(node.name.split('.'), root.results, root);
         }
     });
 
@@ -38,8 +40,10 @@ export default function cleanReducerLeftovers(root) {
  * @param parts
  * @param results
  */
-function cleanNestedFields(parts, results) {
-    const fieldName = parts[0];
+function cleanNestedFields(parts, results, root) {
+    const snapCacheField = root.snapCaches[parts[0]];
+    const fieldName = snapCacheField ? snapCacheField : parts[0];
+
     if (parts.length === 1) {
 
         results.forEach(result => {
@@ -52,7 +56,7 @@ function cleanNestedFields(parts, results) {
     }
 
     parts.shift();
-    cleanNestedFields(parts, results.map(result => result[fieldName]));
+    cleanNestedFields(parts, results.map(result => result[fieldName]), root);
 
     results.forEach(result => {
         if (_.isObject(result[fieldName]) && _.keys(result[fieldName]).length === 0) {

--- a/lib/query/reducers/lib/cleanReducerLeftovers.js
+++ b/lib/query/reducers/lib/cleanReducerLeftovers.js
@@ -43,7 +43,7 @@ function cleanNestedFields(parts, results) {
     if (parts.length === 1) {
 
         results.forEach(result => {
-            if (fieldName !== '_id') {
+            if (_.isObject(result) && fieldName !== '_id') {
                 delete result[fieldName];
             }
         });
@@ -55,7 +55,7 @@ function cleanNestedFields(parts, results) {
     cleanNestedFields(parts, results.map(result => result[fieldName]));
 
     results.forEach(result => {
-        if (_.keys(result[fieldName]).length === 0) {
+        if (_.isObject(result[fieldName]) && _.keys(result[fieldName]).length === 0) {
             if (fieldName !== '_id') {
                 delete result[fieldName];
             }

--- a/lib/query/reducers/lib/embedReducerWithLink.js
+++ b/lib/query/reducers/lib/embedReducerWithLink.js
@@ -17,6 +17,14 @@ export default function embedReducerWithLink(reducerBody, collectionNode) {
 
                 // if it's a link
                 if (linker) {
+                    if (linker.isDenormalized()) {
+                        if (linker.isSubBodyDenormalized(value)) {
+                            const cacheField = linker.linkConfig.denormalize.field;
+                            handleAddField(cacheField, value, collectionNode);
+                            return;
+                        }
+                    }
+
                     embedReducerWithLink(value, collectionNode.getCollectionNode(key));
                     return;
                 }
@@ -24,7 +32,7 @@ export default function embedReducerWithLink(reducerBody, collectionNode) {
                 handleAddField(key, value, collectionNode);
             } else {
                 // does not exist, so it may be a link/reducer/field
-                handleAddElement(root, key, value);
+                handleAddElement(collectionNode, key, value);
             }
         } else {
             // if this field or other reducer exists within the collection

--- a/lib/query/testing/bootstrap/authors/links.js
+++ b/lib/query/testing/bootstrap/authors/links.js
@@ -95,10 +95,17 @@ Authors.addReducers({
                 authorCached: {
                     name: 1,
                 },
+                metadata: {
+                    keywords: 1
+                },
             }
         },
         reduce(object) {
-            return _.first(object.posts).authorCached.name + ' - 2';
+            const firstPost = _.first(object.posts);
+            return {
+                author: firstPost.authorCached,
+                metadata: {...firstPost.metadata},
+            };
         }
     }
 });

--- a/lib/query/testing/bootstrap/authors/links.js
+++ b/lib/query/testing/bootstrap/authors/links.js
@@ -94,6 +94,10 @@ Authors.addReducers({
             posts: {
                 authorCached: {
                     name: 1,
+                    // this tests cleanReducerLeftovers for snapCache fields
+                    profile: {
+                        lastName: 1,
+                    }
                 },
                 metadata: {
                     keywords: 1

--- a/lib/query/testing/bootstrap/authors/links.js
+++ b/lib/query/testing/bootstrap/authors/links.js
@@ -75,5 +75,30 @@ Authors.addReducers({
         reduce(object, params) {
             return params.element;
         }
+    },
+
+    commentsReducer1: {
+        body: {
+            posts: {
+                authorCached: {
+                    name: 1,
+                },
+            }
+        },
+        reduce(object) {
+            return _.first(object.posts).authorCached.name + ' - 1';
+        }
+    },
+    commentsReducer2: {
+        body: {
+            posts: {
+                authorCached: {
+                    name: 1,
+                },
+            }
+        },
+        reduce(object) {
+            return _.first(object.posts).authorCached.name + ' - 2';
+        }
     }
 });

--- a/lib/query/testing/bootstrap/fixtures.js
+++ b/lib/query/testing/bootstrap/fixtures.js
@@ -53,6 +53,9 @@ _.each(authors, (author) => {
     _.each(_.range(POST_PER_USER), (idx) => {
         let post = {
             title: `User Post - ${idx}`,
+            metadata: {
+                keywords: _.sample(TAGS, _.random(1, 2)),
+            },
             createdAt: new Date(),
         };
 

--- a/lib/query/testing/bootstrap/fixtures.js
+++ b/lib/query/testing/bootstrap/fixtures.js
@@ -55,6 +55,9 @@ _.each(authors, (author) => {
             title: `User Post - ${idx}`,
             metadata: {
                 keywords: _.sample(TAGS, _.random(1, 2)),
+                language: {
+                    ..._.sample([{abbr: 'en', title: 'English'}, {abbr: 'de', title: 'Deutsch'}]),
+                }
             },
             createdAt: new Date(),
         };

--- a/lib/query/testing/bootstrap/posts/links.js
+++ b/lib/query/testing/bootstrap/posts/links.js
@@ -43,3 +43,16 @@ Posts.addLinks({
         }
     }
 });
+
+Posts.addReducers({
+    reducerNonExistentNestedField: {
+        body: {
+            nested: {
+                title: 1,
+            }
+        },
+        reduce(object) {
+            return object.nested ? object.nested.title : 'null';
+        }
+    },
+});

--- a/lib/query/testing/bootstrap/posts/links.js
+++ b/lib/query/testing/bootstrap/posts/links.js
@@ -26,5 +26,20 @@ Posts.addLinks({
         collection: Groups,
         metadata: true,
         field: 'groupId'
+    },
+    authorCached: {
+        type: 'one',
+        collection: Authors,
+        field: 'ownerId',
+        denormalize: {
+            field: 'authorCache',
+            body: {
+                name: 1,
+                profile: {
+                    firstName: 1,
+                    lastName: 1,
+                }
+            }
+        }
     }
 });

--- a/lib/query/testing/link-cache/fixtures.js
+++ b/lib/query/testing/link-cache/fixtures.js
@@ -10,7 +10,7 @@ export let groupIds = [];
 export let authorIds = [];
 export let postIds = [];
 
-Meteor.startup(() => {
+export default function createFixtures() {
     for (let i = 0; i < CATEGORIES; i++) {
         const categoryId = Categories.insert({
             name: `Category ${i}`
@@ -53,25 +53,25 @@ Meteor.startup(() => {
             }
         }
     });
+}
 
-    function createPost(authorId) {
-        const postId = Posts.insert({
-            title: `Post ${postIds.length}`,
-            createdAt: new Date(),
-        });
+function createPost(authorId) {
+    const postId = Posts.insert({
+        title: `Post ${postIds.length}`,
+        createdAt: new Date(),
+    });
 
-        postIds.push(postId);
+    postIds.push(postId);
 
-        const authorLink = Posts.getLink(postId, 'author');
-        authorLink.set(authorId);
+    const authorLink = Posts.getLink(postId, 'author');
+    authorLink.set(authorId);
 
-        const randomCategoryId = categoryIds[Math.floor(Math.random()*categoryIds.length)];
+    const randomCategoryId = categoryIds[Math.floor(Math.random()*categoryIds.length)];
 
-        const categoriesLink = Posts.getLink(postId, 'categories');
-        categoriesLink.add(randomCategoryId, {
-            createdAt: new Date(),
-        });
+    const categoriesLink = Posts.getLink(postId, 'categories');
+    categoriesLink.add(randomCategoryId, {
+        createdAt: new Date(),
+    });
 
-        return postId;
-    }
-});
+    return postId;
+}

--- a/lib/query/testing/link-cache/server.test.js
+++ b/lib/query/testing/link-cache/server.test.js
@@ -1,4 +1,4 @@
-import './fixtures';
+import createFixtures from './fixtures';
 import { createQuery } from 'meteor/cultofcoders:grapher';
 import {
     Authors,
@@ -9,9 +9,9 @@ import {
 } from './collections';
 
 describe('Query Link Denormalization', function() {
-    // fixtures run in Meteor.startup()
-    // wait for them to load first
-    Meteor._sleepForMs(10000);
+    before(() => {
+        createFixtures();
+    });
 
     it('Should not cache work with nested options', function() {
         let query = Posts.createQuery({

--- a/lib/query/testing/reducers.client.test.js
+++ b/lib/query/testing/reducers.client.test.js
@@ -201,6 +201,7 @@ describe('Client-side reducers', function() {
                 groupNames: 1,
                 groups: {
                     _id: 1,
+                    name: 1,
                 },
             },
         });
@@ -251,6 +252,7 @@ describe('Client-side reducers', function() {
             data.posts.forEach(post => {
                 assert.isObject(post.authorCached);
                 assert.isDefined(post.authorCached.name);
+        
     
                 // denormalized field should not be present
                 assert.isUndefined(post.authorCache);

--- a/lib/query/testing/reducers.server.test.js
+++ b/lib/query/testing/reducers.server.test.js
@@ -248,4 +248,23 @@ describe('Reducers', function() {
             assert.equal(author.paramBasedReducer, 'TEST_STRING');
         });
     });
+
+    it('Should work with reducers that use deep denormalized nested fields', function() {
+        /**
+         * Both commentsReducers use Posts link on Authors collection and both use denormalized authorCached link
+         * inside the Posts.
+         *
+         * This necessitates the use of embedReducerWithLink() function while creating reducers
+         * which was failing for denormalized fields.
+         */
+        const query = createQuery({
+            authors: {
+                commentsReducer1: 1,
+                commentsReducer2: 1,
+            },
+        });
+
+        const data = query.fetch();
+        assert.isTrue(data.length > 0);
+    });
 });

--- a/lib/query/testing/reducers.server.test.js
+++ b/lib/query/testing/reducers.server.test.js
@@ -256,6 +256,8 @@ describe('Reducers', function() {
          *
          * This necessitates the use of embedReducerWithLink() function while creating reducers,
          * which was failing for denormalized fields and also for nested fields.
+         *
+         * Also, the commentsReducer2 uses nested item in the body, profile: {lastName: 1}
          */
         const query = createQuery({
             authors: {

--- a/lib/query/testing/reducers.server.test.js
+++ b/lib/query/testing/reducers.server.test.js
@@ -267,4 +267,15 @@ describe('Reducers', function() {
         const data = query.fetch();
         assert.isTrue(data.length > 0);
     });
+
+    it('Should allow non-existent nested fields while cleaning', function() {
+        const query = createQuery({
+            posts: {
+                reducerNonExistentNestedField: 1,
+            },
+        });
+
+        const data = query.fetch({limit: 1});
+        assert.equal(data[0].reducerNonExistentNestedField, 'null');
+    });
 });

--- a/lib/query/testing/reducers.server.test.js
+++ b/lib/query/testing/reducers.server.test.js
@@ -254,8 +254,8 @@ describe('Reducers', function() {
          * Both commentsReducers use Posts link on Authors collection and both use denormalized authorCached link
          * inside the Posts.
          *
-         * This necessitates the use of embedReducerWithLink() function while creating reducers
-         * which was failing for denormalized fields.
+         * This necessitates the use of embedReducerWithLink() function while creating reducers,
+         * which was failing for denormalized fields and also for nested fields.
          */
         const query = createQuery({
             authors: {
@@ -265,7 +265,17 @@ describe('Reducers', function() {
         });
 
         const data = query.fetch();
+
         assert.isTrue(data.length > 0);
+        data.forEach(author => {
+            // check if nested denormalized links are working
+            assert.isObject(author.commentsReducer2.author);
+            assert.isTrue(author.commentsReducer2.author.name.startsWith('Author'));
+
+            // check if nested fields are working
+            assert.isObject(author.commentsReducer2.metadata);
+            assert.isTrue(author.commentsReducer2.metadata.keywords.length > 0);
+        });
     });
 
     it('Should allow non-existent nested fields while cleaning', function() {

--- a/lib/query/testing/server.test.js
+++ b/lib/query/testing/server.test.js
@@ -1,4 +1,5 @@
 import { createQuery } from 'meteor/cultofcoders:grapher';
+import dot from 'dot-object';
 import Comments from './bootstrap/comments/collection.js';
 import './metaFilters.server.test';
 import './reducers.server.test';
@@ -567,5 +568,32 @@ describe('Hypernova', function() {
         assert.isObject(user);
         assert.isArray(user.restaurants);
         assert.lengthOf(user.restaurants, 1);
+    });
+
+    it('Should fetch deeply nested fields inside links', function() {
+        const query = createQuery({
+            authors: {
+                posts: {
+                    metadata: {
+                        language: {
+                            abbr: 1,
+                        }
+
+                    }
+                }
+            }
+        });
+
+        const data = query.fetch();
+
+        assert.isTrue(data.length > 0);
+
+        data.forEach(author => {
+            author.posts.forEach(post => {
+                assert.isObject(post.metadata);
+                assert.isObject(post.metadata.language);
+                assert.isDefined(post.metadata.language.abbr);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Reducer fixes
1. Denormalized fields in embedReducerWithLink() were not handled properly causing errors
2. Nested fields in embedReducerWithLink() were not handled properly

Both these issues cause problems while using reducers that use the same link, e.g. 

```
commentsReducer1: {
        body: {
            posts: {
                authorCached: {
                    name: 1,
                },
            }
        },
        ....
    },
    commentsReducer2: {
        body: {
            posts: {
                authorCached: {
                    name: 1,
                },
                metadata: {
                    keywords: 1
                },
            }
        },
    }
```

Both reducers use link posts and inside it denormalized authorCached link which failed in embedReducerWithLink() while handling a linker object.
Using metadata in commentsReducer2  failed when collectionNode.body[key] was not set in embedReducerWithLink().

3. Handling cases when cleaning nested fields inside reducers caused an error if the field did not exist.

4. cleanNestedFields() in reducers failed while cleaning denormalized fields because the field to be cleaned did not exist - node.snapCaches should be used there

## Deeply nested fields inside links fixes
Query such as
```
const query = createQuery({
            authors: {
                posts: {
                    metadata: {
                        language: {
                            abbr: 1,
                        }
                    }
                }
            }
        })
```
failed with **MongoError: FieldPath field names may not contain '.'.**

The thing is that buildAggregatePipeline() used
```
const safeField = field.replace('.', '___');
```
which caused only first dot to be removed.
Now using this
```
const safeField = field.replace(/\./g, SAFE_DOTTED_FIELD_REPLACEMENT);
```

Also, snapBackDottedFields() had to be updated in the same way.

## Denormalized fields in reactive queries - client
After doing some testing, I've also noticed that for reactive queries on client *snapBackCaches()* does not work for nested fields causing denormalized fields not being present on the client.

I think that we need to keep **results** array in the nested collectionNodes because prepareForDelivery depends counts on data being there.

I've added a rather idiotic [fix](https://github.com/cult-of-coders/grapher/pull/263/commits/5a927d27145b5fd9eb85e75f4ada921bb2169f2c#diff-0ff2da97e5451dabdb7fa082495662afR49) and I hope that you'll have some better solutions.
