### PR TITLE
Clarification in migration docs & small spelling fix

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,8 +6,31 @@ When you use reducers with a body that uses a link that should return a single r
 
 ### From 1.2 to 1.3
 
-SimpleSchema has been completely removed and it will no longer extend your Collection's schema automatically, therefore,
-if you have configured links you have to manually add them.
+SimpleSchema has been completely removed and it will no longer extend your Collection's schema automatically, therefore, if you have configured links you have to manually add them.
+
+For example the following link:
+
+```js
+Users.addLinks({
+    post: {
+        type: 'one',
+        collection: Posts,
+        field: 'postId'
+    }
+});
+```
+
+Requires the respective field in your Collection's schema:
+
+```js
+// schema for Users
+SimpleSchema({
+    postId: {
+        type: String,
+        optional: true
+    }
+})
+```
 
 The `metadata` link configuration is no longer an object, but a `Boolean`
 

--- a/docs/query_options.md
+++ b/docs/query_options.md
@@ -74,7 +74,7 @@ Posts.createQuery({
 })
 ```
 
-The query above will fetch as `comments` only the ones that have been approved and that are linekd with the `post`.
+The query above will fetch as `comments` only the ones that have been approved and that are linked with the `post`.
 
 The `$filter` function shares the same `params` across all collection nodes:
 


### PR DESCRIPTION
Been using grapher for a while and finally migrated to 1.3 -- I was stuck migrating for a while and found the migration docs a bit vague. Added an example just in case people were confused like I was. Thanks for the consistent high quality maintenance of this package!