### PR TITLE
Fix #315 - inversedBy links to unique links

### DIFF
--- a/lib/query/lib/prepareForDelivery.js
+++ b/lib/query/lib/prepareForDelivery.js
@@ -96,9 +96,18 @@ export function removeLinkStorages(node, sameLevelResults) {
 
     _.each(node.collectionNodes, collectionNode => {
         const removeStorageField = collectionNode.shouldCleanStorage;
+     
         _.each(sameLevelResults, result => {
             if (removeStorageField) {
-                delete result[collectionNode.linkStorageField];
+                if (collectionNode.isVirtual) {
+                    const childResults = getResultsArray(result[collectionNode.linkName]);
+                    _.each(childResults, childResult => {
+                        delete childResult[collectionNode.linkStorageField];
+                    });
+                }
+                else {
+                    delete result[collectionNode.linkStorageField];
+                }
             }
 
             removeLinkStorages(collectionNode, result[collectionNode.linkName]);
@@ -173,12 +182,13 @@ export function assembleMetadata(node, parentResults) {
                 const childResult = parentResult[node.linkName];
 
                 if (node.isOneResult) {
-                    const storage = childResult[node.linkStorageField];
-                    storeMetadata(childResult, parentResult, storage, true);
+                    if (_.isObject(childResult)) {
+                        const storage = childResult[node.linkStorageField];
+                        storeMetadata(childResult, parentResult, storage, true);
+                    }
                 } else {
                     _.each(childResult, object => {
                         const storage = object[node.linkStorageField];
-
                         storeMetadata(object, parentResult, storage, true);
                     });
                 }

--- a/lib/query/testing/server.test.js
+++ b/lib/query/testing/server.test.js
@@ -14,6 +14,35 @@ const ShoppingCart = new Mongo.Collection('__projection_operators_cart');
 const Clients = new Mongo.Collection('__text_search_clients');
 Clients._ensureIndex({name: 'text'});
 
+Clients.addLinks({
+    shoppingCart: {
+        type: 'one',
+        collection: ShoppingCart,
+        metadata: true,
+        field: 'shoppingCartData',
+        unique: true
+    },
+
+    shoppingCarts: {
+        collection: ShoppingCart,
+        type: 'many',
+        metadata: true,
+        field: 'shoppingCartsData',
+    }
+});
+
+ShoppingCart.addLinks({
+    user: {
+        collection: Clients,
+        inversedBy: 'shoppingCart'
+    },
+
+    users: {
+        collection: Clients,
+        inversedBy: 'shoppingCarts'
+    }
+});
+
 describe('Hypernova', function() {
     it('Should support projection operators', () => {
         ShoppingCart.remove({});
@@ -309,6 +338,8 @@ describe('Hypernova', function() {
                 },
             },
         }).fetch();
+
+        // console.log(JSON.stringify(data, null, 2));
 
         _.each(data, post => {
             assert.isObject(post.author);
@@ -718,5 +749,76 @@ describe('Hypernova', function() {
                 assert.isDefined(post.metadata.language.abbr);
             });
         });
+    });
+
+    it('Should handle empty inversedBy meta unique fields', () => {
+        ShoppingCart.remove({});
+        ShoppingCart.insert({date: new Date(), items: [{title: 'Something'}]});
+
+        const data = ShoppingCart.createQuery({
+            user: {
+                name: 1
+            }
+        }).fetch();
+
+        assert.equal(data.length, 1);
+        const [cart] = data;
+        assert.isUndefined(cart.user);
+    });
+
+    it('Should remove link storage inversedBy meta unique fields', () => {
+        ShoppingCart.remove({});
+        const cartId = ShoppingCart.insert({date: new Date(), items: [{title: 'Something'}]});
+
+        Clients.remove({});
+        Clients.insert({
+            name: 'John',
+            shoppingCartData: {
+                prime: 1,
+                _id: cartId
+            }
+        })
+
+        const data = ShoppingCart.createQuery({
+            user: {
+                name: 1
+            }
+        }).fetch();
+
+        assert.equal(data.length, 1);
+        const [cart] = data;
+        assert.isObject(cart.user);
+        assert.isString(cart.user.name);
+        // no link storage
+        assert.isUndefined(cart.user.shoppingCartData);
+    });
+
+    it('Should remove link storage inversedBy meta many fields', () => {
+        ShoppingCart.remove({});
+        const cartId = ShoppingCart.insert({date: new Date(), items: [{title: 'Something'}]});
+
+        Clients.remove({});
+        Clients.insert({
+            name: 'John',
+            shoppingCartsData: [{
+                prime: 1,
+                _id: cartId
+            }]
+        })
+
+        const data = ShoppingCart.createQuery({
+            users: {
+                name: 1
+            }
+        }).fetch();
+
+        assert.equal(data.length, 1);
+        const [cart] = data;
+        assert.isArray(cart.users);
+        assert.equal(cart.users.length, 1);
+        const [user] = cart.users;
+        assert.isString(user.name);
+        // no link storage
+        assert.isUndefined(user.shoppingCartsData);
     });
 });


### PR DESCRIPTION
This should fix #315. The problem occurred when there was no data on the other side of inversedBy link which referenced unique link.

@theodorDiaconu 
Another issue I noticed while writing tests was that the link storage was not cleared properly so I think I fixed that, too.

And one question. I noticed  that `removeLinkStorages` does not try to delete `$metadata` even when `shouldCleanStorage` flag is true. Is this intentional, ie if we remove $metadata would it break some other things?