### PR TITLE
Recursive fetch update

### DIFF
--- a/lib/query/lib/recursiveFetch.js
+++ b/lib/query/lib/recursiveFetch.js
@@ -55,8 +55,12 @@ function fetch(node, parentObject, fetchOptions = {}) {
              * - pass node.results to accessor above and find with sift
              */
 
-            const currentIds = _.pluck(collectionNode.results, '_id');
-            collectionNode.results.push(...collectionNodeResults.filter(res => !_.contains(currentIds, res._id)));
+            collectionNode.results.push(...collectionNodeResults);
+
+            // this was not working because all references must be replaced in snapBackCaches, not only the ones that are 
+            // found first
+            // const currentIds = _.pluck(collectionNode.results, '_id');
+            // collectionNode.results.push(...collectionNodeResults.filter(res => !_.contains(currentIds, res._id)));
         })
     });
 

--- a/lib/query/testing/bootstrap/index.js
+++ b/lib/query/testing/bootstrap/index.js
@@ -15,4 +15,5 @@ if (Meteor.isServer) {
     Posts.expose();
     Groups.expose();
     Authors.expose();
+    Users.expose();
 }

--- a/lib/query/testing/bootstrap/posts/links.js
+++ b/lib/query/testing/bootstrap/posts/links.js
@@ -41,6 +41,17 @@ Posts.addLinks({
                 }
             }
         }
+    },
+    tagsCached: {
+        collection: Tags,
+        type: 'many',
+        field: 'tagIds',
+        denormalize: {
+            field: 'tagsCache',
+            body: {
+                name: 1
+            }
+        }
     }
 });
 

--- a/lib/query/testing/bootstrap/users/links.js
+++ b/lib/query/testing/bootstrap/users/links.js
@@ -10,5 +10,16 @@ Users.addLinks({
     collection: Users,
     field: 'subordinateIds',
     type: 'many'
-  }
+  },
+  friendsCached: {
+    collection: Users,
+    field: 'friendIds',
+    type: 'many',
+    denormalize: {
+      field: 'friendsCache',
+      body: {
+        name: 1
+      }
+    }
+},
 });

--- a/lib/query/testing/client.test.js
+++ b/lib/query/testing/client.test.js
@@ -270,7 +270,40 @@ describe('Query Client Tests', function () {
         assert.isFunction(clone.setParams({}).fetchOne);
     });
 
+    it('Should work with denormalized fields in the many links', async () => {
+        const query = createQuery({
+            users: {
+                $filters: {
+                    name: {$regex: 'User - (2|3)'}
+                },
+                friends: {
+                    name: 1,
+                    friendsCached: {
+                        name: 1
+                    }
+                }
+            }
+        });
+
+        const handle = query.subscribe();
+        await waitForHandleToBeReady(handle);
+
+        const users = query.fetch();
+
+        assert.equal(users.length, 2);
+        users.forEach(user => {
+            user.friends.forEach(friend => {
+                // each friend should have defined friendsCached
+                assert.isArray(friend.friendsCached);
+                // db cache field should be removed
+                assert.isUndefined(friend.friendCache);
+
+                friend.friendsCached.forEach(cache => assert.isString(cache.name));
+            });
+        });
+    });
+
     it('Should work securely with reactive queries and linked exposures', function () {
 
-    })
+    });
 });


### PR DESCRIPTION
Fixing bug I introduced in earlier PR-s related to reactive queries and handling normalized fields client-side. 

There might be duplicates in `collectionNode.results` in `recursiveFetch` and it is not enough to use only unique subset of these documents, all objects must be added to the results so that `snapBackCaches` can make changes on each instances.