### PR TITLE
Add linkName in error message

### DIFF
--- a/lib/query/nodes/collectionNode.js
+++ b/lib/query/nodes/collectionNode.js
@@ -6,7 +6,7 @@ import {check, Match} from 'meteor/check';
 export default class CollectionNode {
     constructor(collection, body = {}, linkName = null) {
         if (collection && !_.isObject(body)) {
-            throw new Meteor.Error('invalid-body', `Link "${linkName}" is a collection, and should have its body defined as an object.`);
+            throw new Meteor.Error('invalid-body', `The field "${linkName}" is a collection link, and should have its body defined as an object.`);
         }
 
         this.body = deepClone(body);

--- a/lib/query/nodes/collectionNode.js
+++ b/lib/query/nodes/collectionNode.js
@@ -6,7 +6,7 @@ import {check, Match} from 'meteor/check';
 export default class CollectionNode {
     constructor(collection, body = {}, linkName = null) {
         if (collection && !_.isObject(body)) {
-            throw new Meteor.Error('invalid-body', 'Every collection link should have its body defined as an object.');
+            throw new Meteor.Error('invalid-body', `Link "${linkName}" is a collection, and should have its body defined as an object.`);
         }
 
         this.body = deepClone(body);


### PR DESCRIPTION
We've had a hard time tracking down why an invalid query was throwing an error, because we couldn't figure out which field was a collection and had a missing body.

This simply displays the linkName in the error message to make it easier to fix the issue.