### PR TITLE
Fix observer leaks for scoped queries

### DIFF
--- a/lib/query/lib/recursiveCompose.js
+++ b/lib/query/lib/recursiveCompose.js
@@ -18,7 +18,7 @@ function patchCursor(cursor, ns) {
                 callbacks.added(doc);
             };
         }
-        originalObserve.call(cursor, newCallbacks);
+        return originalObserve.call(cursor, newCallbacks);
     };
 }
 


### PR DESCRIPTION
I managed to misread the docs and made a serious bug while patching the `cursor.observe` function.
This only happens to reactively fetched scoped queries.

The `originalObserve` value is not returned from the new function and hence the publishComposite cannot stop the handle when subscription is over.
