### PR TITLE
Add a way to leverage Blaze template `onCreated`.

### DIFF
--- a/lib/namedQuery/namedQuery.client.js
+++ b/lib/namedQuery/namedQuery.client.js
@@ -13,14 +13,15 @@ export default class extends Base {
      * Subscribe
      *
      * @param callback
+     * @param subscriptionContext
      * @returns {null|any|*}
      */
-    subscribe(callback) {
+    subscribe(callback, subscriptionContext = Meteor) {
         if (this.isResolver) {
             throw new Meteor.Error('not-allowed', `You cannot subscribe to a resolver query`);
         }
 
-        this.subscriptionHandle = Meteor.subscribe(
+        this.subscriptionHandle = subscriptionContext.subscribe(
             this.name,
             this.params,
             callback

--- a/lib/namedQuery/namedQuery.client.js
+++ b/lib/namedQuery/namedQuery.client.js
@@ -21,10 +21,27 @@ export default class extends Base {
             throw new Meteor.Error('not-allowed', `You cannot subscribe to a resolver query`);
         }
 
+	let options = {};
+
+	if(typeof callback === 'function') {
+	    options.onReady = callback;
+	} else if(callback && callback.onReady || callback.onStop) {
+	    options = callback;
+	}
+
+	// integrate the onStop hook
+	const oldStop = options.onStop;
+	options.onStop = (...args) => {
+	    this.subscriptionHandle = null;
+
+	    if(oldStop) {
+		oldStop.apply(this, args);
+	    }
+	};
         this.subscriptionHandle = subscriptionContext.subscribe(
             this.name,
             this.params,
-            callback
+            options
         );
 
         return this.subscriptionHandle;


### PR DESCRIPTION
If this.subscribe in the `onCreated` context is used, on can leverage the `subscriptionsReady` helper and Blaze takes care of unsubscribing.

This patch adds an optional `subscriptionContext` Argument for specifing which `subscribe` method to use. 

Example
``` javascript
Template.Seminars_Table.onCreated(function bodyOnCreated() {
      this.listQuery = seminarsListQuery.clone();
      this.listQuery.subscribe(() => {}, this);
});
```
See http://blazejs.org/api/templates.html#Blaze-TemplateInstance-subscribe

Would you be interested in adding this?