### PR TITLE
Fix: #345 calling firewall without params in `getSession()`

### DIFF
--- a/lib/namedQuery/expose/extension.js
+++ b/lib/namedQuery/expose/extension.js
@@ -138,11 +138,11 @@ _.extend(NamedQuery.prototype, {
                 return query.getCursorForCounting();
             },
 
-            getSession(newParams) {
-                self.doValidateParams(newParams);
+            getSession(params) {
+                self.doValidateParams(params);
                 self._callFirewall(this, this.userId, params);
 
-                return { name: self.name, params: newParams };
+                return { name: self.name, params, };
             },
         });
     },


### PR DESCRIPTION
We rename strange named variable `newParams` to `params` in `getSession()` function.

This fixes #345 a non-working firewall for count subscriptions.
