### PR TITLE
Publications should have params in embody

### DIFF
--- a/lib/namedQuery/expose/extension.js
+++ b/lib/namedQuery/expose/extension.js
@@ -74,7 +74,7 @@ _.extend(NamedQuery.prototype, {
      * @param {*} _embody
      * @param {*} body
      */
-    doEmbodimentIfItApplies(body) {
+    doEmbodimentIfItApplies(body, params) {
         // query is not exposed yet, so it doesn't have embodiment logic
         if (!this.exposeConfig) {
             return;
@@ -87,7 +87,7 @@ _.extend(NamedQuery.prototype, {
         }
 
         if (_.isFunction(embody)) {
-            embody.call(this, body, this.params);
+            embody.call(this, body, params);
         } else {
             mergeDeep(body, embody);
         }
@@ -169,7 +169,7 @@ _.extend(NamedQuery.prototype, {
                 body = intersectDeep(body, params.$body);
             }
 
-            self.doEmbodimentIfItApplies(body);
+            self.doEmbodimentIfItApplies(body, params);
             body = prepareForProcess(body, params);
 
             const rootNode = createGraph(self.collection, body);

--- a/lib/namedQuery/namedQuery.server.js
+++ b/lib/namedQuery/namedQuery.server.js
@@ -21,7 +21,7 @@ export default class extends Base {
             }
             
             // we must apply emobdyment here
-            this.doEmbodimentIfItApplies(body);
+            this.doEmbodimentIfItApplies(body, this.params);
 
             const query = this.collection.createQuery(
                 deepClone(body),
@@ -72,7 +72,7 @@ export default class extends Base {
      */
     getCursorForCounting() {
         let body = deepClone(this.body);
-        this.doEmbodimentIfItApplies(body);
+        this.doEmbodimentIfItApplies(body, this.params);
         body = prepareForProcess(body, this.params);
 
         return this.collection.find(body.$filters || {}, {fields: {_id: 1}});


### PR DESCRIPTION
A simple omission, but an `embody` function does not get the `params` when a query is reactive, because `this.params` is never set inside `_initPublication`.

Another option would be to use `setParams` at the start of a publication, not sure what you prefer.