### PR TITLE
Bump peerlibrary:subscription-scope from 0.4.0 to 0.5.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -30,7 +30,7 @@ Package.onUse(function(api) {
         'matb33:collection-hooks@0.8.4',
         'reywood:publish-composite@1.5.2',
         'dburles:mongo-collection-instances@0.3.5',
-        'peerlibrary:subscription-scope@0.4.0',
+        'peerlibrary:subscription-scope@0.5.0',
         'herteby:denormalize@0.6.5',
     ];
 


### PR DESCRIPTION
Version 0.4.0 was causing errors with the latest Meteor build and needed to be republished. These discussions describe the problem:

https://github.com/peerlibrary/meteor-subscription-scope/pull/3
https://github.com/meteor/meteor/pull/10522#issuecomment-533249023

This PR just bumps peerlibrary:subscription-scope from 0.4.0 to 0.5.0 which fixes the issue. 