### PR TITLE
For Many links support partial filter index to allow multiple documents

### DIFF
--- a/lib/links/linker.js
+++ b/lib/links/linker.js
@@ -347,11 +347,23 @@ export default class Linker {
                         );
                     }
 
+                    let options = { unique: true };
+
+                    if (this.isSingle()) {
+                        options = {...options, sparse: true};
+                    } else {
+                        options = {...options,
+                            partialFilterExpression: {
+                                [field]: { $type: 'string' }
+                            }
+                        }
+                    }
+
                     this.mainCollection._ensureIndex(
                         {
                             [field]: 1,
                         },
-                        { unique: true, sparse: true }
+                        options
                     );
                 }
             }

--- a/lib/links/tests/main.js
+++ b/lib/links/tests/main.js
@@ -19,6 +19,12 @@ PostCollection.addLinks({
         field: "commentIds",
         index: true
     },
+    commentsUnique: {
+        type: "*",
+        collection: CommentCollection,
+        field: "commentUniqueIds",
+        unique: true,
+    },
     autoRemoveComments: {
         type: "*",
         collection: CommentCollection,
@@ -54,6 +60,10 @@ CommentCollection.addLinks({
     post: {
         collection: PostCollection,
         inversedBy: "comments"
+    },
+    postUnique: {
+        collection: PostCollection,
+        inversedBy: "commentsUnique"
     },
     inversedPost: {
         collection: PostCollection,
@@ -246,13 +256,17 @@ describe("Collection Links", function() {
         let post = PostCollection.findOne(postId);
         let comment = CommentCollection.findOne(commentId);
         let commentsLink = PostCollection.getLink(post, "comments");
+        let commentsUniqueLink = PostCollection.getLink(post, "commentsUnique");
         let metaCommentsLink = PostCollection.getLink(post, "metaComments");
         let postLink = CommentCollection.getLink(comment, "post");
+        let postUniqueLink = CommentCollection.getLink(comment, "postUnique");
         let postMetaLink = CommentCollection.getLink(comment, "metaPost");
 
         commentsLink.add(comment);
+        commentsUniqueLink.add(comment);
         metaCommentsLink.add(comment);
         assert.lengthOf(postLink.find().fetch(), 1);
+        assert.isObject(postUniqueLink.fetch());
         assert.lengthOf(postMetaLink.find().fetch(), 1);
 
         CommentCollection.remove(comment._id);
@@ -433,4 +447,13 @@ describe("Collection Links", function() {
 
         assert.equal('someData', result.oneMeta.$metadata.data);
     });
+
+    it("Should not result in duplicate key error on Many Unique links", function() {
+      let postIdA = PostCollection.insert({ text: "abc" });
+      let postIdB = PostCollection.insert({ text: "abc" });
+
+      PostCollection.remove(postIdA);
+      PostCollection.remove(postIdB);
+    });
+
 });


### PR DESCRIPTION
with the empty array.

Many unique relationships are valid (i.e. posts and comments) but currently indexing them results in ` BulkWriteError: E11000 duplicate key error collection: meteor.test_post index: commentUniqueIds_1 dup key: { : null }`.

This PR addresses this by using `partialFilterExpression` if `!this.isSingle()` so that empty arrays do not cause duplicate key errors.