### PR TITLE
Filter out undefined values from filterAssembledData()

### DIFF
--- a/lib/query/hypernova/assembler.js
+++ b/lib/query/hypernova/assembler.js
@@ -99,8 +99,11 @@ export default (childCollectionNode, { limit, skip, metaFilters }) => {
 };
 
 function filterAssembledData(data, { limit, skip }) {
-    if (limit && Array.isArray(data)) {
-        return data.slice(skip, limit);
+    if (Array.isArray(data)) {
+        data = data.filter(Boolean);
+        if (limit) {
+            return data.slice(skip, limit);
+        }
     }
 
     return data;

--- a/lib/query/testing/server.test.js
+++ b/lib/query/testing/server.test.js
@@ -50,6 +50,83 @@ ShoppingCart.addLinks({
 });
 
 describe("Hypernova", function() {
+
+    it("Should not crash due to nested filters", () => {
+        const id = `Nested filters_${Random.id()}`;
+        const A = new Mongo.Collection(`${id}_a`);
+        const B = new Mongo.Collection(`${id}_b`);
+        const C = new Mongo.Collection(`${id}_c`);
+
+        B.addLinks({
+            as: {
+                type: 'many',
+                collection: A,
+                field: 'a_ids',
+                unique: true,
+            }
+        });
+
+        A.addLinks({
+            b: {
+                collection: B,
+                inversedBy: 'as',
+            },
+
+            c: {
+                type: 'one',
+                collection: C,
+                field: 'c_id',
+            },
+        });
+
+        const cId = C.insert({
+            foo: true
+        });
+
+        const aIdA = A.insert({
+            foo: true,
+            bar: true,
+            c_id: cId,
+        });
+
+        const aIdB = A.insert({
+            foo: true,
+            bar: false,
+            c_id: cId,
+        });
+
+        B.insert({
+            foo: true,
+            a_ids: [aIdA, aIdB],
+        });
+
+        const data = A.createQuery({
+          $filters: {
+            foo: true,
+          },
+          b: {
+              $filters: {
+                foo: true,
+              },
+              as: {
+                  $filters: {
+                    foo: true,
+                    bar: true,
+                  },
+                  c: {
+                      foo: 1,
+                  }
+              }
+          }
+        }).fetch();
+
+        assert.lengthOf(data, 2);
+        assert.lengthOf(data[0].b.as, 1);
+        assert.lengthOf(data[1].b.as, 1);
+        assert.isTrue(data[0].b.as[0].c.foo);
+        assert.isTrue(data[1].b.as[0].c.foo);
+    });
+
     it("Should support projection operators", () => {
         ShoppingCart.remove({});
         ShoppingCart.insert({


### PR DESCRIPTION
Having undefined values in parent.results is causing all sorts of bugs in prepareForDelivery.js due to accessing fields of "undefined" in node.results.