### PR TITLE
LinkMany $pull fix

### DIFF
--- a/lib/links/linkTypes/linkMany.js
+++ b/lib/links/linkTypes/linkMany.js
@@ -72,8 +72,8 @@ export default class LinkMany extends Link {
 
         // update the db
         let modifier = {
-            $pull: {
-                [root]: nested.length > 0 ? {[nested.join('.')]: {$in: _ids}} : {$in: _ids},
+            $pullAll: {
+                [root]: nested.length > 0 ? { [nested.join('.')]: _ids } : _ids,
             },
         };
 

--- a/lib/links/tests/client.test.js
+++ b/lib/links/tests/client.test.js
@@ -1,0 +1,31 @@
+import { assert } from "chai";
+
+
+describe("Links Client Tests", function() {
+
+    it("Test remove many", function() {
+        let PostCollection = new Mongo.Collection(null);
+        let CommentCollection = new Mongo.Collection(null);
+
+        PostCollection.addLinks({
+            comments: {
+                type: "many",
+                collection: CommentCollection,
+                field: "commentIds",
+                index: true,
+            }
+        });
+
+        let postId = PostCollection.insert({ text: "abc" });
+        let commentId = CommentCollection.insert({ text: "abc" });
+
+        const link = PostCollection.getLink(postId, "comments");
+        link.add(commentId);
+        assert.lengthOf(link.find().fetch(), 1);
+
+        link.remove(commentId);
+
+        assert.lengthOf(link.find().fetch(), 0);
+    });
+
+});

--- a/package.js
+++ b/package.js
@@ -61,6 +61,7 @@ Package.onTest(function(api) {
 
   // LINKS
   api.addFiles("lib/links/tests/main.js", "server");
+  api.addFiles("lib/links/tests/client.test.js", "client");
 
   // EXPOSURE
   api.addFiles("lib/exposure/testing/server.js", "server");


### PR DESCRIPTION
There is a limitation in minimongo's handling of $pull, so this simple new test in which a comment is removed via linkMany from its post causes the following error on the client:

```
Error: Unrecognized logical operator: $in
    at packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:642:15
    at Array.map (<anonymous>)
    at compileDocumentSelector (packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:635:48)
    at Matcher._compileSelector (packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:4013:12)
    at new Matcher (packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:3944:29)
    at $pull (packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:3653:23)
    at packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:3075:9
    at Array.forEach (<anonymous>)
    at packages/minimongo.js?hash=bb17400235469027310b81f0d525d28875f12863:3057:28
    at Array.forEach (<anonymous>)
```