### PR TITLE
Remove strict meteor package versions

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,21 +17,25 @@ Npm.depends({
   "deep-extend": "0.5.0"
 });
 
+const corePackages = [
+    "matb33:collection-hooks",
+    "reywood:publish-composite",
+    "dburles:mongo-collection-instances",
+    "herteby:denormalize"
+    "mongo",
+    "underscore",
+    "ecmascript",
+];
+
 Package.onUse(function(api) {
   api.versionsFrom("1.3");
 
   var packages = [
-    "ecmascript",
-    "underscore",
     "promise",
     "check",
     "reactive-var",
-    "mongo",
-    "matb33:collection-hooks@0.8.4",
-    "reywood:publish-composite@1.5.2",
-    "dburles:mongo-collection-instances@0.3.5",
-    "peerlibrary:subscription-scope@0.5.0",
-    "herteby:denormalize@0.6.5"
+    "peerlibrary:subscription-scope",
+    ...corePackages
   ];
 
   api.use(packages);
@@ -45,13 +49,7 @@ Package.onTest(function(api) {
 
   var packages = [
     "random",
-    "ecmascript",
-    "underscore",
-    "matb33:collection-hooks@0.8.4",
-    "reywood:publish-composite@1.5.2",
-    "dburles:mongo-collection-instances@0.3.5",
-    "herteby:denormalize@0.6.5",
-    "mongo"
+    ...corePackages
   ];
 
   api.use(packages);

--- a/package.js
+++ b/package.js
@@ -18,13 +18,13 @@ Npm.depends({
 });
 
 const corePackages = [
-    "matb33:collection-hooks",
-    "reywood:publish-composite",
-    "dburles:mongo-collection-instances",
-    "herteby:denormalize"
-    "mongo",
-    "underscore",
-    "ecmascript",
+  "matb33:collection-hooks",
+  "reywood:publish-composite",
+  "dburles:mongo-collection-instances",
+  "herteby:denormalize",
+  "mongo",
+  "underscore",
+  "ecmascript"
 ];
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Grapher's strict package versions prevents me from updating to the latest packages, including those from `Meteor-Community-Packages`.

I went through git blame and noticed there wasn't a commit message explaining why these packages were pinned (and not other).

So, let's see what the tests say!