### PR TITLE
Fix for storeOneResults when handling already processed results

### DIFF
--- a/lib/query/lib/prepareForDelivery.js
+++ b/lib/query/lib/prepareForDelivery.js
@@ -142,7 +142,7 @@ export function removeLinkStorages(node, sameLevelResults) {
 }
 
 export function storeOneResults(node, sameLevelResults) {
-    if (!sameLevelResults) {
+    if (!sameLevelResults || !_.isArray(sameLevelResults)) {
         return;
     }
 

--- a/lib/query/testing/server.test.js
+++ b/lib/query/testing/server.test.js
@@ -49,6 +49,33 @@ ShoppingCart.addLinks({
     }
 });
 
+// for storeOneResults tests
+const Level1 = new Mongo.Collection('level1');
+const Level2 = new Mongo.Collection('level2');
+const Level3 = new Mongo.Collection('level3');
+const Level4 = new Mongo.Collection('level4');
+Level1.addLinks({
+    level2: {
+        type: 'one',
+        collection: Level2,
+        field: 'level2Id',
+    },
+});
+Level2.addLinks({
+    level3: {
+        type: 'one',
+        collection: Level3,
+        field: 'level3Id',
+    },
+});
+Level3.addLinks({
+    level4: {
+        type: 'one',
+        collection: Level4,
+        field: 'level4Id',
+    },
+})
+
 describe("Hypernova", function() {
 
     it("Should not crash due to nested filters", () => {
@@ -588,6 +615,71 @@ describe("Hypernova", function() {
         });
 
         assert.isTrue(arrivedInDepth);
+    });
+
+    it("Should not throw when nested fields have identical documents", function() {
+        Level1.remove({});
+        Level2.remove({});
+        Level3.remove({});
+        Level4.remove({});
+
+        /**
+         * When prepareForDelivery() calls storeOneResults() in case of deep nested fields, sometimes
+         * it happens that in sameLevelResults are passed non-array values resulting in incorrent behaviour
+         * with for example null fields.
+         * 
+         * Consider the example (only links are shown and all links are of type one):
+         * 
+         * RootDoc1 --
+         *             \
+         *               => Child => GrandChild => GrandGrandChild
+         *             /
+         * RootDoc2 -- 
+         * 
+         * - RootDoc1 and RootDoc2 share the *same* Child object.
+         * - storeOneResults() mutates objects
+         * 
+         * What happens:
+         * 0. We fetched the results in hypernova and now we are in prepareForDeliver() calling storeOneResults()
+         * 1. At first: 
+         *      both RootDoc1 and RootDoc2 have an array of length 1 in Child field,
+         *      Child has array of GrandChild of length 1
+         *      GrandChild has array of GrandGrandChild of length 1
+         *  
+         * 2. Since storeOneResults() is recursive it comes to the bottom of the graph first, removing array on GrandChild.GrandGrandChild
+         * 3. Then it removes GrandChild array on Child document.
+         * 4. After that it goes to the RootDoc2 instance, but since object are shared between RootDoc1 and RootDoc2,
+         * in recursive call result[collectionNode.linkName] is no longer array, but object.
+         * Therefore, _.each(sameLevelResults) now iterates over object with all kind of unwanted consequences.
+         * 
+         * sampleField in example below is show how null field can force prepareToDelivery() into crash with
+         * error "Cannot read property 'level4' of null"
+         * 
+         */
+
+        const level4Id = Level4.insert({title: 'Level 4'});
+        const level3Id = Level3.insert({title: 'Level 3', level4Id, sampleField: null});
+        const level2Id = Level2.insert({title: 'Level 2', level3Id});
+
+        Level1.insert({title: 'Level 1 #1', level2Id});
+        Level1.insert({title: 'Level 1 #2', level2Id});
+
+        expect(() => {
+            Level1.createQuery({
+                title: 1,
+                level2: {
+                    title: 1,
+                    sampleField: 1,
+                    level3: {
+                        title: 1,
+                        sampleField: 1,
+                        level4: {
+                            title: 1,
+                        },
+                    },
+                },
+            }).fetch();
+        }).to.not.throw();
     });
 
     it("Should work with filters of $and and $or on subcollections", function() {


### PR DESCRIPTION
Adds check in `storeOneResults()` function to handle already processed collection results.
It can happen that instead of an array, an object is passed to the function.
