### PR TITLE
Always check object exists before accessing its properties

### DIFF
--- a/lib/query/lib/prepareForDelivery.js
+++ b/lib/query/lib/prepareForDelivery.js
@@ -150,7 +150,7 @@ export function storeOneResults(node, sameLevelResults) {
         _.each(sameLevelResults, result => {
             // The reason we are doing this is that if the requested link does not exist
             // It will fail when we try to get undefined[something] below
-            if (result === undefined) {
+            if (!result) {
                 return;
             }
 


### PR DESCRIPTION
This result value can not only be undefined, but also null sometimes. This simple fix prevents grapher from having really deep crashes.

Similar issue as https://github.com/cult-of-coders/grapher/issues/315.

Here's a sample stack trace:

```sh
I20191202-14:01:20.224(1)? Exception while invoking method 'myMethod' TypeError: Cannot read property
 'contacts' of null
I20191202-14:01:20.224(1)?     at _.each.result (packages/cultofcoders:grapher/lib/query/lib/prepareForDel
ivery.js:157:51)
I20191202-14:01:20.224(1)?     at Function._.each._.forEach (packages/underscore.js:147:22)
I20191202-14:01:20.224(1)?     at node.collectionNodes.forEach.collectionNode (packages/cultofcoders:graph
er/lib/query/lib/prepareForDelivery.js:150:11)
I20191202-14:01:20.224(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.224(1)?     at storeOneResults (packages/cultofcoders:grapher/lib/query/lib/prepareForD
elivery.js:149:26)
I20191202-14:01:20.224(1)?     at _.each.result (packages/cultofcoders:grapher/lib/query/lib/prepareForDel
ivery.js:157:13)
I20191202-14:01:20.225(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.225(1)?     at Function._.each._.forEach (packages/underscore.js:139:11)
I20191202-14:01:20.225(1)?     at node.collectionNodes.forEach.collectionNode (packages/cultofcoders:graph
er/lib/query/lib/prepareForDelivery.js:150:11)
I20191202-14:01:20.225(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.225(1)?     at storeOneResults (packages/cultofcoders:grapher/lib/query/lib/prepareForD
elivery.js:149:26)
I20191202-14:01:20.225(1)?     at _.each.result (packages/cultofcoders:grapher/lib/query/lib/prepareForDel
ivery.js:157:13)
I20191202-14:01:20.226(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.226(1)?     at Function._.each._.forEach (packages/underscore.js:139:11)
I20191202-14:01:20.226(1)?     at node.collectionNodes.forEach.collectionNode (packages/cultofcoders:graph
er/lib/query/lib/prepareForDelivery.js:150:11)
I20191202-14:01:20.226(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.226(1)?     at storeOneResults (packages/cultofcoders:grapher/lib/query/lib/prepareForD
elivery.js:149:26)
I20191202-14:01:20.226(1)?     at _.each.result (packages/cultofcoders:grapher/lib/query/lib/prepareForDel
ivery.js:157:13)
I20191202-14:01:20.227(1)?     at Array.forEach (<anonymous>)
I20191202-14:01:20.227(1)?     at Function._.each._.forEach (packages/underscore.js:139:11)
I20191202-14:01:20.227(1)?     at node.collectionNodes.forEach.collectionNode (packages/cultofcoders:graph
er/lib/query/lib/prepareForDelivery.js:150:11)
I20191202-14:01:20.227(1)?     at Array.forEach (<anonymous>)
```