### PR TITLE
Package: upgrade matb33:collection-hooks 1.0.1

### DIFF
--- a/package.js
+++ b/package.js
@@ -27,7 +27,7 @@ Package.onUse(function(api) {
     "check",
     "reactive-var",
     "mongo",
-    "matb33:collection-hooks@0.8.4",
+    "matb33:collection-hooks@1.0.1",
     "reywood:publish-composite@1.5.2",
     "dburles:mongo-collection-instances@0.3.5",
     "peerlibrary:subscription-scope@0.5.0",


### PR DESCRIPTION
Hi, this MR update the dependency matb33:collection-hooks to the latest available.
matb33:collection-hooks [1.0.0 include a breaking-change (minimal meteor version) ](https://github.com/Meteor-Community-Packages/meteor-collection-hooks/releases/tag/v1.0.0).

I don't find any specification for the minimal Meteor version, so i think the next release of grapher need to be a major version 2.0.0.