### PR TITLE
Corrects error messages thrown by linkMany

### DIFF
--- a/lib/links/linkTypes/linkMany.js
+++ b/lib/links/linkTypes/linkMany.js
@@ -90,7 +90,7 @@ export default class LinkMany extends Link {
             return this;
         }
 
-        throw new Meteor.Error('invalid-command', 'You are trying to *set* in a relationship that is single. Please use add/remove for *many* relationships');
+        throw new Meteor.Error('invalid-command', 'You are trying to *set* in a relationship that is many. Please use add/remove for *many* relationships');
     }
 
     unset(what) {
@@ -101,6 +101,6 @@ export default class LinkMany extends Link {
             return this;
         }
 
-        throw new Meteor.Error('invalid-command', 'You are trying to *unset* in a relationship that is single. Please use add/remove for *many* relationships');
+        throw new Meteor.Error('invalid-command', 'You are trying to *unset* in a relationship that is many. Please use add/remove for *many* relationships');
     }
 }


### PR DESCRIPTION
The wording of the error messages being thrown is for single links, not many links.