### PR TITLE
Allow unblocking recursive publications

### DIFF
--- a/lib/exposure/exposure.js
+++ b/lib/exposure/exposure.js
@@ -136,6 +136,10 @@ export default class Exposure {
         const getTransformedBody = this.getTransformedBody.bind(this);
 
         Meteor.publishComposite(this.name, function(body) {
+            if (!config.blocking) {
+                this.unblock();
+            }
+
             let transformedBody = getTransformedBody(body);
 
             const rootNode = createGraph(collection, transformedBody);
@@ -145,6 +149,7 @@ export default class Exposure {
 
             return recursiveCompose(rootNode, this.userId, {
                 bypassFirewalls: !!config.body,
+                blocking: config.blocking,
             });
         });
     }

--- a/lib/namedQuery/expose/extension.js
+++ b/lib/namedQuery/expose/extension.js
@@ -174,7 +174,10 @@ _.extend(NamedQuery.prototype, {
 
             const rootNode = createGraph(self.collection, body);
 
-            return recursiveCompose(rootNode, undefined, {scoped: isScoped});
+            return recursiveCompose(rootNode, undefined, {
+                scoped: isScoped,
+                blocking: self.exposeConfig.blocking,
+            });
         });
     },
 

--- a/lib/query/lib/recursiveCompose.js
+++ b/lib/query/lib/recursiveCompose.js
@@ -27,6 +27,10 @@ function compose(node, userId, config) {
     return {
         find(parent) {
             if (parent) {
+                if (!config.blocking) {
+                    this.unblock();
+                }
+
                 let {filters, options} = applyProps(node);
 
                 // composition
@@ -58,6 +62,10 @@ function compose(node, userId, config) {
 export default (node, userId, config = {bypassFirewalls: false, scoped: false}) => {
     return {
         find() {
+            if (!config.blocking) {
+                this.unblock();
+            }
+
             let {filters, options} = applyProps(node);
 
             const cursor = node.collection.find(filters, options, userId);


### PR DESCRIPTION
This PR lets the `blocking: true` parameter in your config pass through to publications. From the comment [here](Meteor-Community-Packages/meteor-publish-composite#48), it seems like it doesn't cause any problems.

As a general rule in my team, we think you should never block any code with Meteor anyways, as you should cascade any subsequent calls on the client side. Assuming code will execute in the right order is a bad idea, always use callbacks, chained promises, or simply synchronous code.

Testing this in production now, will report back with some results :)